### PR TITLE
Fixes random characters being displayed after manufacturer and product names

### DIFF
--- a/src/scnp-cli-main.c
+++ b/src/scnp-cli-main.c
@@ -261,6 +261,7 @@ char *ludh_alloc_string_descriptor(libusb_device_handle *dev_handle,
     COND_OR_FAIL(ret != NULL, "malloc OOM");
 
     strncpy(ret, (char *)buf, size_t_get_sd_ascii);
+    ret[size_t_get_sd_ascii] = '\0';
 
     return ret;
 }


### PR DESCRIPTION
Existing code in main gives random characters after the manufacturer and product names because these have not been null-terminated before being passed to printf. Since we’re already malloc’ing 1 byte more, it should be safe to just null-terminate the string that’s being returned.

Before:

    # ./scnp-cli audio-routing 3
    Bus 001 Device 019: ID 05fc:0030 Soundcraftܤ� Notepad-5�ܤ� (firmware 1.09)
    Setting USB audio source to 3 (MASTER L+R) for device NOTEPAD-5
    device_send_ctrl_message(device, {00 00 04 00 03 00 00 00})

After:

    #  ./scnp-cli audio-routing 3
    Bus 001 Device 019: ID 05fc:0030 Soundcraft Notepad-5 (firmware 1.09)
    Setting USB audio source to 3 (MASTER L+R) for device NOTEPAD-5
    device_send_ctrl_message(device, {00 00 04 00 03 00 00 00})
